### PR TITLE
Don't print workbench folders when loading

### DIFF
--- a/InitGui.py
+++ b/InitGui.py
@@ -56,8 +56,6 @@ class PolyhydronsWorkbench (Workbench):
         
         import workbenchfolders
         
-        print (workbenchfolders.recommended_folders)
-        
         basedir = str(FreeCAD.getUserAppDataDir())
         folder = ""
         


### PR DESCRIPTION
It's best practice not to print any superfluous text to the console during startup.
![image](https://github.com/eddyverl/FreeCAD-Pyramids-and-Polyhedrons/assets/37948669/77f8f4f0-c885-48d1-aa6e-156abef397ef)
