### PR TITLE
Don't override default display mode methods in viewprovider

### DIFF
--- a/polyhedrons.py
+++ b/polyhedrons.py
@@ -134,15 +134,6 @@ class ViewProviderBox:
     def updateData(self, fp, prop):
         return
 
-    def getDisplayModes(self,obj):
-        return "As Is"
-
-    def getDefaultDisplayMode(self):
-        return "As Is"
-
-    def setDisplayMode(self,mode):
-        return "As Is"
-
     def onChanged(self, vobj, prop):
         pass
 


### PR DESCRIPTION
returning a string from `getDisplayModes` is incorrect:

![image](https://github.com/user-attachments/assets/e744d741-1966-488f-9c8f-8d46becd9943)

There's no need to implement these methods for this workbench's use case.